### PR TITLE
refactor: remove safeMode because Broweserless got rid of it

### DIFF
--- a/src/Browserless.php
+++ b/src/Browserless.php
@@ -17,10 +17,6 @@ class Browserless extends AbstractPDF
     private $pdfEndpoint = '/pdf';
 
     /**
-     * @var bool
-     */
-    private $safeMode = false;
-    /**
      * @var int|null
      */
     private $rotate;
@@ -38,19 +34,6 @@ class Browserless extends AbstractPDF
     public function setRotation(?int $rotation = null): self
     {
         $this->rotate = $rotation;
-        return $this;
-    }
-
-    /**
-     * Sets whether or not to ask Browserless to attempt to render the document in safe mode
-     *
-     * @link https://docs.browserless.io/docs/pdf.html#safemode
-     * @param  bool $safeMode
-     * @return self
-     */
-    public function setSafeMode(bool $safeMode): self
-    {
-        $this->safeMode = $safeMode;
         return $this;
     }
 
@@ -74,16 +57,6 @@ class Browserless extends AbstractPDF
     public function getTimeout(): ?int
     {
         return $this->timeout;
-    }
-
-    /**
-     * Whether the document will be rendered in safe mode or not
-     *
-     * @return bool
-     */
-    public function getSafeMode(): bool
-    {
-        return $this->safeMode;
     }
 
     /**
@@ -151,7 +124,6 @@ class Browserless extends AbstractPDF
 
         $options = [
             'options' => $pdfOptions,
-            'safeMode' => $this->getSafeMode(),
         ];
 
         $goto = [];


### PR DESCRIPTION
### Fixes an error:

**Error: "Failed to render from Browserless: POST Body validation failed: "safeMode" is not allowed"**

### Issue:

Browserless 2.0

**/pdf API**
The PDF API operates in a similar fashion as the in browserless 1.xx. The biggest difference is how launch flags are handled, which now use a consolidated launch object to hold all CLI arguments and flags.

waitFor has now been removed and deprecated in favor of puppeteer's discrete API methods: waitForEvent, waitForFunction, waitForSelector and waitForTimeout.

rotate has been removed due to lack of usage and included 3rd party dependencies. safeMode has also been removed in favor of using puppeteer's streaming capabilities that are much less error-prone.

**Source:** https://docs.browserless.io/baas/migrate#pdf-api:~:text=safeMode%20has%20also%20been%20removed%20in%20favor%20of%20using%20puppeteer%27s%20streaming%20capabilities%20that%20are%20much%20less%20error%2Dprone